### PR TITLE
allows props as array

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -526,8 +526,15 @@ function handlePropType(n?: SyntaxNode): string {
   return ret
 }
 
-function handleProps(state: State, o: SyntaxNode, transformPass = true) { // ObjectNode
-  handleObject(o, {
+function handleProps(state: State, s: SyntaxNode, transformPass = true) { // ObjectNode or ArrayNode
+  console.log(s)
+  if (s.type === 'array') {
+    handleArray(s, (n: SyntaxNode) => {
+        state.props[n.text] = 'any';
+    })
+    return;
+  }
+  handleObject(s, {
     onKeyValue(propName: string, n: SyntaxNode) {
       switch (n.type) {
         case "identifier":
@@ -564,7 +571,7 @@ function handleProps(state: State, o: SyntaxNode, transformPass = true) { // Obj
       }
     },
     onMethod(meth: string, async: boolean, args: SyntaxNode, block: SyntaxNode) {
-      fail(`unexpected prop method: ${meth}`, o) // XXX wrong syntax node here
+      fail(`unexpected prop method: ${meth}`, s) // XXX wrong syntax node here
     },
   })
 }
@@ -776,7 +783,7 @@ function handleDefaultExportKeyValue(state: State, key: string, n: SyntaxNode, t
       // do nothing with this...
       break
     case "props":
-      assert(n.type === "object", `expected props to be an object: ${n.type}`, n)
+      assert(n.type === "object" || n.type === "array", `expected props to be an object or array: ${n.type}`, n)
       handleProps(state, n, transformPass)
       break
     case "watch":

--- a/src/core.ts
+++ b/src/core.ts
@@ -527,7 +527,6 @@ function handlePropType(n?: SyntaxNode): string {
 }
 
 function handleProps(state: State, s: SyntaxNode, transformPass = true) { // ObjectNode or ArrayNode
-  console.log(s)
   if (s.type === 'array') {
     handleArray(s, (n: SyntaxNode) => {
         state.props[n.text] = 'any';

--- a/tests/fixtures/propsArray/input.vue
+++ b/tests/fixtures/propsArray/input.vue
@@ -1,0 +1,5 @@
+<script>
+export default {
+    props: ['id']
+}
+</script>

--- a/tests/fixtures/propsArray/output.vue
+++ b/tests/fixtures/propsArray/output.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+defineProps<{
+  'id'?: any
+}>()
+</script>


### PR DESCRIPTION
Fixes #2. All tests pass.

```
> vue-o2c@0.1.12 test ~/src/vue-o2c
> tsx tests/index.ts

- defineComponent
- empty
- propsArray
- transformNode
- useSemisAndDoubleQuotes

Tests succeeded!
```